### PR TITLE
Run custom cd on shell initialization

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -41,3 +41,5 @@ cd()
     return $?
   fi
 }
+
+cd $PWD


### PR DESCRIPTION
When I am happily working away in a terminal tab and open another at the same place I'd like it the `.env` to get run again to set up the new shell. Hence, `cd $PWD`.

It's possible this is even dirtier than overriding cd, but it's working for me!
