### PR TITLE
Explicit authorization

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -67,7 +67,9 @@ autoenv_check_authz_and_run()
 {
   typeset envfile
   envfile=$1
-  if ! autoenv_check_authz "$envfile"; then
+  if autoenv_check_authz "$envfile"; then
+    source "$envfile"
+  else
     autoenv_env
     autoenv_env "WARNING:"
     autoenv_env "This is the first time you are about to source $envfile":


### PR DESCRIPTION
Explicit authorization is required the first time for each new `.env` file, and also every time the `.env` file's contents have been modified. It keeps a list of SHA hashes in `~/.autoenv_authorized`.
