### PR TITLE
Handle case where grep is an alias to egrep or grep -E

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -60,7 +60,7 @@ autoenv_check_authz()
   envfile=$1
   hash=$(autoenv_hashline "$envfile")
   touch $AUTOENV_AUTH_FILE
-  grep -Gq "$hash" $AUTOENV_AUTH_FILE
+  \grep -Gq "$hash" $AUTOENV_AUTH_FILE
 }
 
 autoenv_check_authz_and_run()


### PR DESCRIPTION
egrep -G (grep -EG) results in:
    egrep: conflicting matchers specified

Which results in the auth check happening every time. This forces it to not pay attention to such aliases.
