### PR TITLE
Helper method `use_env` to load virtualenvs quickly.

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -115,3 +115,23 @@ autoenv_cd()
 cd() {
   autoenv_cd "$@"
 }
+
+
+# The use_env call below is a reusable command to activate/create a new Python
+# virtualenv, requiring only a single declarative line of code in your .env files.
+# It only performs an action if the requested virtualenv is not the current one.
+use_env() {
+  typeset venv
+  venv="$1"
+  if [[ "${VIRTUAL_ENV:t}" != "$venv" ]]; then
+    if workon | grep -q "$venv"; then
+      workon "$venv"
+    else
+      echo -n "Create virtualenv \"$venv\" now? (Yn) "
+      read answer
+      if [[ "$answer" != "n" ]]; then
+        mkvirtualenv "$venv"
+      fi
+    fi
+  fi
+}


### PR DESCRIPTION
The function `use_env` is added to the autoenv shell script, so it is sourced and available to be used inside `.env` scripts.  This makes it easy to declare what virtualenv should be loaded or created when switching to a specific dir.

For example:

```
use_env myenv
```

The function is cheap when the environment is already active and will only invoke the expensive `workon` and `mkvirtualenv` commands when absolutely necessary.
### Disclaimer

You could argue that autoenv is not the best project to bundle this script with and you should be better off including it in `.zshrc`, but I think a lot of people can profit from this as activating virtualenvs is the main use for autoenv anyway.

So, :sparkles: :cake: :sparkles: ?
