### PR TITLE
Added a cd . to force autoenv to search for an env file

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -117,3 +117,5 @@ autoenv_cd()
 cd() {
   autoenv_cd "$@"
 }
+
+cd .


### PR DESCRIPTION
Added a cd . because when you load autoenv, it should actually check for an env file.
A good example is when you are working on a project and you want to open a new tab from your terminal, it will open inside project dir, however cd is never called, so you have to access a folder to activate a virtualenv for example.
