### PR TITLE
Add newline after contents.

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -78,6 +78,7 @@ autoenv_check_authz_and_run()
     autoenv_env
     autoenv_env "    --- (begin contents) ---------------------------------------"
     autoenv_indent "$envfile"
+    autoenv_env
     autoenv_env "    --- (end contents) -----------------------------------------"
     autoenv_env
     autoenv_printf "Are you sure you want to allow this? (y/N) "


### PR DESCRIPTION
This might not be major, but it's been an annoyance for me for some time now.

This improves the formatting of the prompt by adding a newline after `.env`'s contents.
