### PR TITLE
Make .env file collection robust against cd output

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -20,7 +20,7 @@ autoenv_init()
       if [[ -e "${_file}" ]]
       then echo "${_file}"
       fi
-      builtin cd ..
+      builtin cd .. &>/dev/null
     done
   ) )
 


### PR DESCRIPTION
This pull-request redirects any output from `builtin cd` to `/dev/null`, so it doesn't end up in `_files`.  This is needed if people have set up `chpwd` in zsh to output something, [e.g. to update the terminal title bar](http://www.refining-linux.org/archives/42/ZSH-Gem-8-Hook-function-chpwd/).
