### PR TITLE
Use `chpwd_functions` array in zsh instead of overriding `cd`

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -115,8 +115,12 @@ autoenv_cd()
   fi
 }
 
-cd() {
-  autoenv_cd "$@"
-}
+if [[ -z "$ZSH_VERSION" ]]; then
+  cd() {
+    autoenv_cd "$@"
+  }
+else
+  chpwd_functions=( autoenv_init $chpwd_functions )
+fi
 
 cd .


### PR DESCRIPTION
This is a better way to load autoenv than overriding `cd` in zsh, because with
this method, autoenv will work fine even if auto_cd option is turned on in zsh
(typing just the directory name without a `cd` to change directory).

And (as a minor point) it produces cleaner error message,

```
autoenv_cd:cd:2: no such file or directory: non-existent
```

vs.

```
cd: no such file or directory: non-existent
```
