### PR TITLE
Add autoenv_run() for manually executing files

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -33,6 +33,12 @@ autoenv_init()
   done
 }
 
+autoenv_run() {
+  typeset _file
+  _file="$(realpath "$1")"
+  autoenv_check_authz_and_run "${_file}"
+}
+
 autoenv_env() {
   builtin echo "autoenv:" "$@"
 }


### PR DESCRIPTION
When running autoenv_check_authz_and_run from command lines there are two
obvious problems:
1. The command is ugly
2. It does not expect to find a relative path and adds a relative path to the
   auth file

I am using this new command inside my .env file to differentiate between global
and local environment settings. Now I can upload my .env into Git while my
passwords and environment-local settings (eg. PATH) will be hooked from my
`.local` file. This is my example .env:

```
use_env killer_app
export DATABASE_URL='postgres://root@localhost'

LOCAL_FILE=".local"
if [ -f $LOCAL_FILE -a ! -z $AUTOENV_AUTH_FILE ]; then
    autoenv_run "$LOCAL_FILE"
fi
```

This provides some additional security when collaborating with others and
sharing some environment defaults needed by a 12 factor app.
