### PR TITLE
Handle the case where grep is an alias to egrep same way as autoenv_check_authz() do

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -100,7 +100,7 @@ autoenv_deauthorize_env() {
   typeset envfile
   envfile=$1
   cp "$AUTOENV_AUTH_FILE" "$AUTOENV_AUTH_FILE.tmp"
-  grep -Gv "$envfile:" "$AUTOENV_AUTH_FILE.tmp" > $AUTOENV_AUTH_FILE
+  \grep -Gv "$envfile:" "$AUTOENV_AUTH_FILE.tmp" > $AUTOENV_AUTH_FILE
 }
 
 autoenv_authorize_env() {


### PR DESCRIPTION
egrep -G (grep -EG) results in conflicting matchers.

This change complements change made a year agou in autoenv_check_authz().
