### PR TITLE
`eval` the content of AUTOENV env variable after `source`ing a `.env`.

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -117,6 +117,14 @@ autoenv_authorize_env() {
   autoenv_hashline "$envfile" >> $AUTOENV_AUTH_FILE
 }
 
+autoenv_source() {
+  typeset allexport
+  allexport=$(set +o | grep allexport)
+  set -a
+  source "$1"
+  eval "$allexport"
+}
+
 autoenv_cd()
 {
   if builtin cd "$@"


### PR DESCRIPTION
This allows including commands in a .env without breaking other tools like foreman. See also https://github.com/kennethreitz/autoenv/issues/28#issuecomment-20444719
