### PR TITLE
if a file named `.autoenv` exists, just `source` it

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -31,6 +31,14 @@ autoenv_init()
     autoenv_check_authz_and_run "$envfile"
     : $(( _file -= 1 ))
   done
+
+  _file="$PWD/.autoenv"
+  if [[ -e "${_file}" ]]
+  then 
+  autoenv_check_authz "${_file}"
+  source "${_file}"
+  fi
+
 }
 
 autoenv_run() {


### PR DESCRIPTION
this allows the execution of arbitrary commands while still allowing foreman to be used.

The use case is having a `.env` file with env vars for foreman, but still wanting` autoenv` to activate a virtual environment.
