### PR TITLE
fixed shasum for osx now

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -56,7 +56,7 @@ autoenv_hashline()
 {
   typeset envfile hash
   envfile=$1
-  if [[ -a shasum ]]
+  if [[ $(which shasum) ]]
   then hash=$(shasum "$envfile" | cut -d' ' -f 1)
   else hash=$(sha1sum "$envfile" | cut -d' ' -f 1)
   fi


### PR DESCRIPTION
Simple fix to work with OSX or where shasum exists instead of sha1sum.

-bash: sha1sum: command not found
