### PR TITLE
Change check for shasum

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -56,7 +56,7 @@ autoenv_hashline()
 {
   typeset envfile hash
   envfile=$1
-  if [[ -a shasum ]]
+  if which shasum &> /dev/null
   then hash=$(shasum "$envfile" | cut -d' ' -f 1)
   else hash=$(sha1sum "$envfile" | cut -d' ' -f 1)
   fi


### PR DESCRIPTION
shasum wasn't getting found on OS X 10.9.1 with zsh 5.0.5, updated check.
