### PR TITLE
now works fine with directories having space in name

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -8,6 +8,9 @@ fi
 
 autoenv_init()
 {
+  defIFS=$IFS
+  IFS=$(echo -en "\n\b")
+
   typeset target home _file
   typeset -a _files
   target=$1
@@ -31,6 +34,8 @@ autoenv_init()
     autoenv_check_authz_and_run "$envfile"
     : $(( _file -= 1 ))
   done
+
+  IFS=$defIFS
 }
 
 autoenv_run() {


### PR DESCRIPTION
it doesn't work for directories having whitespaces in their names
like `pravj@pravj-HP:~/Desktop/testing/auto env/`

addition in this pull request changes the `IFS` variable on runtime to support whitespaces also, working fine now

there is already an issue for this problem, here #40

can you see this please, @kennethreitz