### PR TITLE
allow to set env-filename via env vars

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 AUTOENV_AUTH_FILE=~/.autoenv_authorized
+if [ -z "$AUTOENV_ENV_FILENAME" ]; then
+    AUTOENV_ENV_FILENAME=.env
+fi
 
 if [[ -n "${ZSH_VERSION}" ]]
 then __array_offset=0
@@ -16,7 +19,7 @@ autoenv_init()
   _files=( $(
     while [[ "$PWD" != "/" && "$PWD" != "$home" ]]
     do
-      _file="$PWD/.env"
+      _file="$PWD/$AUTOENV_ENV_FILENAME"
       if [[ -e "${_file}" ]]
       then echo "${_file}"
       fi


### PR DESCRIPTION
This patch allow to change .env to custom name in easy way. I often use autoenv with vagrant boxes, and I need to read custom .env files in vagrant box, but not in host. I can automate now, that every new vagrant box will search for file .env-$(hostname) :)
