### PR TITLE
Do not use aliases for `cp` (as with `grep`)

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -102,7 +102,7 @@ autoenv_check_authz_and_run()
 autoenv_deauthorize_env() {
   typeset envfile
   envfile=$1
-  cp "$AUTOENV_AUTH_FILE" "$AUTOENV_AUTH_FILE.tmp"
+  \cp "$AUTOENV_AUTH_FILE" "$AUTOENV_AUTH_FILE.tmp"
   \grep -Gv "$envfile:" "$AUTOENV_AUTH_FILE.tmp" > $AUTOENV_AUTH_FILE
 }
 


### PR DESCRIPTION
Given an alias `cp='cp -i'`, autoenv_deauthorize_env would ask for
confirmation.

The better fix would be using `sed -i` probably.
