### PR TITLE
Ignore directory .env, keep searching

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -20,7 +20,7 @@ autoenv_init()
     while [[ "$PWD" != "/" && "$PWD" != "$home" ]]
     do
       _file="$PWD/$AUTOENV_ENV_FILENAME"
-      if [[ -e "${_file}" ]]
+      if [[ -f "${_file}" ]]
       then echo "${_file}"
       fi
       builtin cd .. &>/dev/null


### PR DESCRIPTION
Without this, autoenv thinks a directory is a file and
asks to allow executing it. Autoenv only works for
regular files.

URL: http://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html