### PR TITLE
Add note about temporarily disabling autoenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,9 @@ Disclaimer
 
 Autoenv overrides ``cd``. If you already do this, invoke ``autoenv_init`` within your custom ``cd`` after sourcing ``activate.sh``.
 
+Autoenv can be disabled via ``unset cd`` if you experience I/O issues with
+certain file systems, particularly those that are FUSE-based (such as 
+``smbnetfs``).
 
 Testing
 -------


### PR DESCRIPTION
Trying to source .env causes I/O errors on smbnetfs mounts; disabling autoenv is an easy answer.