### PR TITLE
Add autoenv activation to pip installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ Using pip
 ::
 
     $ pip install autoenv
+    $ echo "source `which activate.sh`" >> ~/.bashrc
 
 
 Using git


### PR DESCRIPTION
Installing with pip still requires autoenv to be activated.

Fixes #70