### PR TITLE
Accept 'Y' or 'y' for prompt

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -100,7 +100,7 @@ autoenv_check_authz_and_run()
     autoenv_env
     autoenv_printf "Are you sure you want to allow this? (y/N) "
     read answer
-    if [[ "$answer" == "y" ]]; then
+    if [ "$answer" == "y" ] || [ "$answer" == "Y" ]; then
       autoenv_authorize_env "$envfile"
       autoenv_source "$envfile"
     fi


### PR DESCRIPTION
I'm not sure if the syntax is right (I'm not much of a bash scripter), but this should address issue #88.