### PR TITLE
Fix security issue using hidden characters

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -57,7 +57,7 @@ autoenv_printf() {
 }
 
 autoenv_indent() {
-  sed 's/.*/autoenv:     &/' $@
+ cat -e $@ | sed 's/.*/autoenv:     &/' 
 }
 
 autoenv_hashline()


### PR DESCRIPTION
Thank to @keruspe who have pointed me than auto env was sensible to this kind of security issue : http://seclists.org/fulldisclosure/2015/Sep/75

So this patch allow to print hidden characters to be sure autoenv will print evil code if it's hide that way

Before
``` 
denis:~ waxzce$ cd /Users/waxzce/work/tmp/autot
autoenv:
autoenv: WARNING:
autoenv: This is the first time you are about to source /Users/waxzce/work/tmp/autot/.env:
autoenv:
autoenv:     --- (begin contents) ---------------------------------------
autoenv:     #!/bin/bash
autoenv:     echo doing something very nice!
autoenv:     --- (end contents) -----------------------------------------
autoenv:
autoenv: Are you sure you want to allow this? (y/N) ^C
denis:autot waxzce$
```



After
```
denis:~ waxzce$ cd /Users/waxzce/work/tmp/autot
autoenv:
autoenv: WARNING:
autoenv: This is the first time you are about to source /Users/waxzce/work/tmp/autot/.env:
autoenv:
autoenv:     --- (begin contents) ---------------------------------------
autoenv:     #!/bin/bash$
autoenv:     echo doing something evil!$
autoenv:     exit$
autoenv:     ^[[2Aecho doing something very nice!$
autoenv:
autoenv:     --- (end contents) -----------------------------------------
autoenv:
autoenv: Are you sure you want to allow this? (y/N) ^C
```


use to create an evil .env 
```
printf '#!/bin/bash\necho doing something evil!\nexit\n\033[2Aecho doing something very nice!\n' > .env
```
