### PR TITLE
Add a missing enable_autoenv if shasum is the only tool available

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -160,6 +160,7 @@ elif which shasum 2>/dev/null >&2; then
     autoenv_shasum() {
         shasum "$@"
     }
+    enable_autoenv
 else
     echo "Autoenv cannot locate a compatible shasum binary; not enabling"
 fi


### PR DESCRIPTION
On my current machine, I currently only have `shasum` installed, not the other binaries. I noticed that `autoenv` wasn't working until I added this line. Looks like a simple copy/paste error.