### PR TITLE
Suppress "Will run" output if AUTOENV_QUIET is defined. (Fixes #126)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,7 @@ Before sourcing activate.sh, you can set the following variables:
 - ``AUTOENV_AUTH_FILE``: Authorized env files, defaults to ``~/.autoenv_authorized``
 - ``AUTOENV_ENV_FILENAME``: Name of the ``.env`` file, defaults to ``.env``
 - ``AUTOENV_LOWER_FIRST``: Set this variable to flip the order of ``.env`` files exectued
+- ``AUTOENV_QUIET``: Set this variable to any value to prevent the displaying of filenames after a ``cd``
 
 Shells
 ------

--- a/activate.sh
+++ b/activate.sh
@@ -50,7 +50,7 @@ ${_orderedfiles}"
 
 	# Execute the env files
 	for _file in ${_orderedfiles}; do
-		echo "Will run ${_file}"
+		[ -z "${AUTOENV_QUIET}" ] && echo "Will run ${_file}"
 		autoenv_check_authz_and_run "${_file}"
 	done
 	IFS="${origIFS}"


### PR DESCRIPTION
Current output gets noisy when `cd`ing through subfolders and further
down the tree.