### PR TITLE
redirect ouput of cd command to /dev/null

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -29,7 +29,7 @@ autoenv_init() {
 ${_file}"
 				fi
 			fi
-			command -v chdir >/dev/null 2>&1 && chdir .. || builtin cd ..
+			command -v chdir >/dev/null 2>&1 && chdir .. >/dev/null 2>&1 || builtin cd .. >/dev/null 2>&1 
 		done
 	`"
 	set +x


### PR DESCRIPTION
Some `cd` commands (e.g. when using autols) are rather verbose.

On my machine "cd" automatically prints out the files in the new directory.
"autoenv" considered this output as part of the list of directories containing ".env" files. 
This lead to strange errors, e.g. "autoenv" assumed that "var@" is a ".env" file, because it was in the result of the function collecting ".env" files