### PR TITLE
Update README - OSX install directions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Mac OS X Using Homebrew
 ::
 
     $ brew install autoenv
-    $ echo 'source $(brew --prefix autoenv)/activate.sh' >> ~/.bash_profile
+    $ echo "source $(brew --prefix autoenv)/activate.sh" >> ~/.bash_profile
 
 
 Using pip


### PR DESCRIPTION
I think it would be preferable to use the double quote instead of the single for the bash profile addition. The brew install location of autoenv is unlikely to change, and evaluating it once saves about half a second every time bash_profile gets executed.

Please let me know what you think!