### PR TITLE
Add an "assume yes" feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,7 @@ Before sourcing activate.sh, you can set the following variables:
 - ``AUTOENV_AUTH_FILE``: Authorized env files, defaults to ``~/.autoenv_authorized``
 - ``AUTOENV_ENV_FILENAME``: Name of the ``.env`` file, defaults to ``.env``
 - ``AUTOENV_LOWER_FIRST``: Set this variable to flip the order of ``.env`` files executed
+- ``AUTOENV_ASSUME_YES``: Set this variable to silently authorize the initialization of new environments
 
 Shells
 ------

--- a/activate.sh
+++ b/activate.sh
@@ -87,6 +87,11 @@ autoenv_check_authz_and_run() {
 		autoenv_source "${_envfile}"
 		\return 0
 	fi
+	if [ "${AUTOENV_ASSUME_YES}" = "true" ] || [ "${AUTOENV_ASSUME_YES}" = "TRUE" ]; then # Don't ask for permission if "assume yes" is switched on
+		autoenv_authorize_env "${_envfile}"
+		autoenv_source "${_envfile}"
+                \return 0
+        fi
 	if [ -z "${MC_SID}" ]; then # Make sure mc is not running
 		\echo "autoenv:"
 		\echo "autoenv: WARNING:"

--- a/activate.sh
+++ b/activate.sh
@@ -87,7 +87,7 @@ autoenv_check_authz_and_run() {
 		autoenv_source "${_envfile}"
 		\return 0
 	fi
-	if [ "${AUTOENV_ASSUME_YES}" = "true" ] || [ "${AUTOENV_ASSUME_YES}" = "TRUE" ]; then # Don't ask for permission if "assume yes" is switched on
+	if [ -n "${AUTOENV_ASSUME_YES}" ]; then # Don't ask for permission if "assume yes" is switched on
 		autoenv_authorize_env "${_envfile}"
 		autoenv_source "${_envfile}"
                 \return 0


### PR DESCRIPTION
Adding a feature that overrides the initial sourcing prompt to create a "silent" switching.
Initialize the `.env` file without asking for permission when an environment variable named `AUTOENV_ASSUME_YES` is set to either `TRUE` or `true`.