### PR TITLE
Improvements for portability, security

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -3,11 +3,8 @@ AUTOENV_ENV_FILENAME="${AUTOENV_ENV_FILENAME:-.env}"
 
 autoenv_init() {
 	local _mountpoint _files _orderedfiles _sedregexp _pwd
-	if [ "${OSTYPE#darwin*}" != "${OSTYPE}" ]; then
-		_sedregexp='-E'
-	else
-		_sedregexp='-r'
-	fi
+	_sedregexp='-E'
+
 	_mountpoint="$(df -P "${PWD}" | tail -1 | awk '{ for(i=6; i<NF; i++) printf "%s",$i OFS; if(NF) printf "%s",$NF; printf ORS}')"
 	# Remove double slashes, see #125
 	_pwd="`\echo "${PWD}" | \sed "${_sedregexp}" 's:/+:/:g'`"

--- a/activate.sh
+++ b/activate.sh
@@ -5,7 +5,7 @@ autoenv_init() {
 	local _mountpoint _files _orderedfiles _sedregexp _pwd
 	_sedregexp='-E'
 
-	_mountpoint="$(df -P "${PWD}" | tail -1 | awk '{ for(i=6; i<NF; i++) printf "%s",$i OFS; if(NF) printf "%s",$NF; printf ORS}')"
+	_mountpoint="$(df -P "${PWD}" | tail -n 1 | awk '{ for(i=6; i<NF; i++) printf "%s",$i OFS; if(NF) printf "%s",$NF; printf ORS}')"
 	# Remove double slashes, see #125
 	_pwd="`\echo "${PWD}" | \sed "${_sedregexp}" 's:/+:/:g'`"
 	# Discover all files we need to source

--- a/activate.sh
+++ b/activate.sh
@@ -5,7 +5,7 @@ autoenv_init() {
 	local _mountpoint _files _orderedfiles _sedregexp _pwd
 	_sedregexp='-E'
 
-	_mountpoint="$(df -P "${PWD}" | tail -n 1 | awk '{ for(i=6; i<NF; i++) printf "%s",$i OFS; if(NF) printf "%s",$NF; printf ORS}')"
+	_mountpoint="$(df -P "${PWD}" | tail -n 1 | awk '{ for(i=6; i<NF; i++) printf "%s",$i OFS} END {print $NF}')"
 	# Remove double slashes, see #125
 	_pwd=$(\echo "${PWD}" | \sed "${_sedregexp}" 's:/+:/:g')
 	# Discover all files we need to source


### PR DESCRIPTION
Since `autoenv` can be use in many shells and by itself used many external commands, so it's better to stick with POSIX standard command options, syntax.

This PR makes many changes to make sure `autoenv` will work in shells which are tested and should be work in any other POSIX compliant shell, system.