### PR TITLE
execute .env.leave file when leaving a directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,11 +8,13 @@ What is it?
 -----------
 
 If a directory contains a ``.env`` file, it will automatically be executed
-when you ``cd`` into it.
+when you ``cd`` into it. When enabled (set ``AUTOENV_ENABLE_LEAVE`` to a non-null string),
+if a directory contains a ``.env.leave`` file, it will automatically be executed when you leave it.
 
 This is great for...
 
 - auto-activating virtualenvs
+- auto-deactivating virtualenvs
 - project-specific environment variables
 - making millions
 
@@ -85,6 +87,8 @@ Before sourcing activate.sh, you can set the following variables:
 - ``AUTOENV_AUTH_FILE``: Authorized env files, defaults to ``~/.autoenv_authorized``
 - ``AUTOENV_ENV_FILENAME``: Name of the ``.env`` file, defaults to ``.env``
 - ``AUTOENV_LOWER_FIRST``: Set this variable to flip the order of ``.env`` files executed
+- ``AUTOENV_ENV_LEAVE_FILENAME``: Name of the ``.env.leave`` file, defaults to ``.env.leave``
+- ``AUTOENV_ENABLE_LEAVE``: Set this to a non-null string in order to enable source env when leaving
 
 Shells
 ------

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,13 @@ autoenv is tested on:
 - fish is supported by `autoenv_fish <https://github.com/loopbit/autoenv_fish>`_
 - more to come
 
+Alternatives
+------------
+
+Direnv is an excellent alternative to autoenv, and includes the ability to unset environment variables as well. It also supports the fish terminal. 
+
+`https://direnv.net <https://direnv.net>`_
+
 
 Disclaimer
 ----------

--- a/activate.sh
+++ b/activate.sh
@@ -5,7 +5,7 @@ AUTOENV_ENV_LEAVE_FILENAME="${AUTOENV_ENV_LEAVE_FILENAME:-.env.leave}"
 
 autoenv_init() {
 
-	if [ ! -z $AUTOENV_ENABLE_LEAVE ]; then
+	if [ -n "$AUTOENV_ENABLE_LEAVE" ]; then
 		autoenv_leave "$@"
 	fi
 

--- a/activate.sh
+++ b/activate.sh
@@ -1,5 +1,7 @@
 AUTOENV_AUTH_FILE="${AUTOENV_AUTH_FILE:-$HOME/.autoenv_authorized}"
 AUTOENV_ENV_FILENAME="${AUTOENV_ENV_FILENAME:-.env}"
+AUTOENV_ENV_LEAVE_FILENAME="${AUTOENV_ENV_LEAVE_FILENAME:-.env.leave}"
+# AUTOENV_ENABLE_LEAVE
 
 autoenv_init() {
 	local _mountpoint _files _orderedfiles _sedregexp _pwd
@@ -63,6 +65,10 @@ ${_orderedfiles}"
 	if [ -z "${zsh_shwordsplit}" ]; then
 		\unsetopt shwordsplit >/dev/null 2>&1
 	fi
+
+    if [ ! -z $AUTOENV_ENABLE_LEAVE ]
+        autoenv_leave "$@"
+    fi
 }
 
 autoenv_hashline() {
@@ -137,13 +143,23 @@ autoenv_source() {
 }
 
 autoenv_cd() {
+    local _pwd
+    _pwd=${PWD}
 	\command -v chdir >/dev/null 2>&1 && \chdir "${@}" || builtin cd "${@}"
 	if [ "${?}" -eq 0 ]; then
-		autoenv_init
+		autoenv_init "${_pwd}"
 		\return 0
 	else
 		\return "${?}"
 	fi
+}
+
+autoenv_leave() {
+    # execute file when leaving a directory
+    local target_file dir
+    dir="${@}"
+    target_file="${dir}/${AUTOENV_ENV_LEAVE_FILENAME}"
+    [ -f "${target_file}" ] && autoenv_check_authz_and_run "${target_file}"
 }
 
 # Override the cd alias

--- a/activate.sh
+++ b/activate.sh
@@ -4,6 +4,11 @@ AUTOENV_ENV_LEAVE_FILENAME="${AUTOENV_ENV_LEAVE_FILENAME:-.env.leave}"
 # AUTOENV_ENABLE_LEAVE
 
 autoenv_init() {
+
+    if [ ! -z $AUTOENV_ENABLE_LEAVE ]; then
+        autoenv_leave "$@"
+    fi
+
 	local _mountpoint _files _orderedfiles _sedregexp _pwd
 	if [ "${OSTYPE#darwin*}" != "${OSTYPE}" ]; then
 		_sedregexp='-E'
@@ -65,10 +70,6 @@ ${_orderedfiles}"
 	if [ -z "${zsh_shwordsplit}" ]; then
 		\unsetopt shwordsplit >/dev/null 2>&1
 	fi
-
-    if [ ! -z $AUTOENV_ENABLE_LEAVE ]
-        autoenv_leave "$@"
-    fi
 }
 
 autoenv_hashline() {


### PR DESCRIPTION
When used with virtualenv, we can source .env file when entering a directory and activate an environment. But when leaving it, it will not be automatically deactivated. This implementation provides a solution, it will source .env.leave file when leaving working directory. But it also contains issues, such as when entering an environment, we cannot enter subdirectories, because it will be automatically deactivated( We are LEAVING current working directory), but we can also put additional .env file under those directories.