### PR TITLE
Add ALIAS_FUNC_DEF option for zsh

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -154,7 +154,7 @@ autoenv_cd() {
 
 # Override the cd alias
 if setopt 2> /dev/null | grep -q aliasfuncdef; then
-	alias_func_def_status=true;
+	has_alias_func_def_enabled=true;
 else
 	setopt ALIAS_FUNC_DEF 2> /dev/null
 fi
@@ -167,7 +167,7 @@ enable_autoenv() {
 	cd "${PWD}"
 }
 
-if ! $alias_func_def_status; then
+if ! $has_alias_func_def_enabled; then
 	unsetopt ALIAS_FUNC_DEF 2> /dev/null
 fi
 

--- a/activate.sh
+++ b/activate.sh
@@ -153,6 +153,12 @@ autoenv_cd() {
 }
 
 # Override the cd alias
+if setopt 2> /dev/null | grep -q aliasfuncdef; then
+	alias_func_def_status=true;
+else
+	setopt ALIAS_FUNC_DEF 2> /dev/null
+fi
+
 enable_autoenv() {
 	cd() {
 		autoenv_cd "${@}"
@@ -160,6 +166,10 @@ enable_autoenv() {
 
 	cd "${PWD}"
 }
+
+if ! $alias_func_def_status; then
+	unsetopt ALIAS_FUNC_DEF 2> /dev/null
+fi
 
 # Probe to see if we have access to a shasum command, otherwise disable autoenv
 if command -v gsha1sum 2>/dev/null >&2 ; then


### PR DESCRIPTION
Bug info https://bugs.debian.org/871816
Another solution might be that those who use zsh put `setopt ALIAS_FUNC_DEF` in `.zshrc`

Fix: https://github.com/kennethreitz/autoenv/issues/173
