### PR TITLE
Prettier file contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Before sourcing activate.sh, you can set the following variables:
     enable source env when leaving
   - `AUTOENV_ASSUME_YES`: Set this variable to a non-null string to silently authorize the
     initialization of new environments
+  - `AUTOENV_VIEWER`: Array containing external program and args used to view
+    env files prior to authorization. Should be a list with the program name
+    and any arguments. Default: `( less -N )`.
 
 ## Shells
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,8 @@ Before sourcing activate.sh, you can set the following variables:
     enable source env when leaving
   - `AUTOENV_ASSUME_YES`: Set this variable to a non-null string to silently authorize the
     initialization of new environments
-  - `AUTOENV_VIEWER`: Array containing external program and args used to view
-    env files prior to authorization. Should be a list with the program name
-    and any arguments. Default: `( less -N )`.
+  - `AUTOENV_VIEWER`: Program used to display env files prior to authorization.
+    Default: `"less -N"`.
 
 ## Shells
 

--- a/activate.sh
+++ b/activate.sh
@@ -1,24 +1,119 @@
 AUTOENV_AUTH_FILE="${AUTOENV_AUTH_FILE:-$HOME/.autoenv_authorized}"
 AUTOENV_ENV_FILENAME="${AUTOENV_ENV_FILENAME:-.env}"
 AUTOENV_ENV_LEAVE_FILENAME="${AUTOENV_ENV_LEAVE_FILENAME:-.env.leave}"
-AUTOENV_VIEWER=()
+# AUTOENV_VIEWER
 # AUTOENV_ENABLE_LEAVE
 
-# choose a viewer if not already set
-autoenv_setup() {
-  [[ ${#AUTOENV_VIEWER[@]} -gt 0 ]] && return
+# _autoenv_info -- print a user message to stdout
+#
+# args:
+# -b[NUM]     number of lines to print before message
+# -a[NUM]     number of lines to print after message (default=1)
+# -n          do not print trailing newline (same as -a0)
+# MESSAGE     space seperated text of message
+#
+# usage: _autoenv_info [-n] [-b[NUM]] MESSAGE...
+#
+_autoenv_info() {
+  local after=1 before=0
+
+  while : ; do
+    case "$1" in
+      -n)  after=0                           ;;
+      -b*) before=${1#-b} ; : "${before:=1}" ;;
+      -a*) after=${1#-a}  ; : "${after:=1}"  ;;
+      *)   break                             ;;
+    esac
+    shift
+  done
+
+  [ $before -gt 0 ] && printf '%*s' ${before} | tr " " "\n"
+
+  if [ -n "$NO_COLOR" ]; then
+    \printf "[autoenv] %s" "${*}"
+  else
+    \printf "\033[33m[autoenv]\033[0m %s" "${*}"
+  fi
+
+  [ $after -gt 0 ] && printf '%*s' ${after} | tr " " "\n"
+}
+
+# _autoenv_err -- print a message to stderr
+#
+# args:
+# MESSAGE     space seperated text of message
+#
+# usage: _autoenv_err MESSAGE...
+#
+_autoenv_err() {
+  if [ -n "$NO_COLOR" ]; then
+    \printf "[autoenv] Error %s" "${*}" >&2
+  else
+    \printf "\033[33m[autoenv]\033[0m \033[31mError\033[0m %s\n" "${*}" >&2
+  fi
+
+  return 1
+}
+
+# _autoenv_find_viewer -- set AUTOENV_VIEWER program is missing
+#                         (a one-time setup function)
+#
+_autoenv_find_viewer() {
+  [ -n "${AUTOENV_VIEWER}" ] && return
+
   while read -r prog args; do
     if command -v $prog > /dev/null; then
-      AUTOENV_VIEWER=( "$prog" ${args[@]} )
+      AUTOENV_VIEWER="$prog $args"
       return
     fi
   done <<EOF
-  bat --style=numbers
   less -N
+  nl -ba
   cat
 EOF
+
 }
-autoenv_setup
+_autoenv_find_viewer
+
+# _autoenv_draw_line -- print a horizontal line
+#
+# args:
+# * TEXT: title to print near the beginning of the line
+#
+# usage: _autoenv_draw_line [TEXT]
+#
+_autoenv_draw_line() {
+  local text="${1}" char="-" width=${COLUMNS:-80} margin=3 line
+
+  if [ -n "${text}" ]; then
+    text="--- ${text} "
+  fi
+
+  width=$((width-${#text}-margin))
+  line=$(printf '%*s\n' ${width} | tr " " "${char}")
+
+  if [ -n "$NO_COLOR" ]; then
+    \printf "%s%s\n\n" "${text}" "$line"
+  else
+    \printf "\033[1m%s%s\033[0m\n\n" "${text}" "$line"
+  fi
+}
+
+# _autoenv_show_file -- display the contents of a .env or .env.leave file
+#                      using the $AUTOENV_VIEWER command
+#
+# usage: _autoenv_show_file FILE
+#
+_autoenv_show_file() {
+  local file="$1" ofs="$IFS"
+
+  _autoenv_info -b "New or modified env file detected:"
+  _autoenv_draw_line "${file##*/} contents"
+  IFS=" "
+  $AUTOENV_VIEWER "${file}"
+  IFS="$ofs"
+  _autoenv_draw_line
+}
 
 autoenv_init() {
 
@@ -107,80 +202,6 @@ autoenv_check_authz() {
 	\command grep -q "${_hash}" -- "${AUTOENV_AUTH_FILE}"
 }
 
-# autoenv_message -- print a user message to stdout
-#
-# args:
-# -n          do not print trailing newline
-# MESSAGE     space seperated text of message
-#
-# usage: autoenv_message [-n] MESSAGE...
-#
-#
-autoenv_message() {
-  local no_newline
-
-  if [[ "$1" == "-n" ]]; then
-    no_newline=true
-    shift
-  fi
-
-  if [[ -n "$NOCOLOR" ]]; then
-    \printf "[autoenv] %s" "${*}"
-  else
-    \printf "\033[33m[autoenv]\033[0m %s" "${*}"
-  fi
-
-  if [[ -z "${no_newline}" ]]; then
-    \printf "\n"
-  fi
-}
-
-autoenv_error() {
-  if [[ -n "$NOCOLOR" ]]; then
-    \printf "[autoenv] Error %s" "${*}" >&2
-  else
-    \printf "\033[33m[autoenv]\033[0m \033[31mError\033[0m %s\n" "${*}" >&2
-  fi
-
-  return 1
-}
-
-# display the contents of a .env or .env.leave file
-#   using the $AUTOENV_VIEWER command
-autoenv_show_file() {
-  local file="$1"
-
-  \echo
-  autoenv_message "New or modified env file detected:"
-  _autoenv_line "${file##*/} contents"
-  "${AUTOENV_VIEWER[@]}" "${file}"
-  _autoenv_line
-}
-
-# _autoenv_line -- print a horizontal line
-#
-# args:
-# * TEXT: title to print near the beginning of the line
-#
-# usage: _autoenv_line [TEXT]
-#
-_autoenv_line() {
-  local text="${1}" char="-" width=${COLUMNS:-80}
-
-  if [[ -n "${text}" ]]; then
-    text="--- ${text} "
-    width=$((width-${#text}))
-  fi
-
-  read -r line < <(eval "printf -- '${char}%.0s' {1..${width}}")
-
-  if [[ -n "$NOCOLOR" ]]; then
-    \printf "%s%s\n\n" "${text}" "$line"
-  else
-    \printf "\033[1m%s%s\033[0m\n\n" "${text}" "$line"
-  fi
-}
-
 autoenv_check_authz_and_run() {
 	local _envfile
 	_envfile="${1}"
@@ -194,9 +215,9 @@ autoenv_check_authz_and_run() {
                 \return 0
         fi
 	if [ -z "${MC_SID}" ]; then # Make sure mc is not running
-    autoenv_show_file "${_envfile}"
-    autoenv_message -n "Authorize this file? (y/N) "
-		\read answer
+    _autoenv_show_file "${_envfile}"
+    _autoenv_info -n "Authorize this file? (y/N) "
+		\read -r answer
 		if [ "${answer}" = "y" ] || [ "${answer}" = "Y" ]; then
 			autoenv_authorize_env "${_envfile}"
 			autoenv_source "${_envfile}"
@@ -237,8 +258,7 @@ autoenv_source() {
 autoenv_cd() {
 	local _pwd
 	_pwd=${PWD}
-	\command -v chdir >/dev/null 2>&1 && \chdir "${@}" || builtin cd "${@}"
-	if [ "${?}" -eq 0 ]; then
+  if \command -v chdir >/dev/null 2>&1 && \chdir "${@}" || builtin cd "${@}"; then
 		autoenv_init "${_pwd}"
 		\return 0
 	else
@@ -290,5 +310,5 @@ elif command -v shasum 2>/dev/null >&2; then
 	}
 	enable_autoenv
 else
-	autoenv_error "can not locate a compatible shasum binary; not enabling"
+	_autoenv_err "can not locate a compatible shasum binary; not enabling"
 fi

--- a/activate.sh
+++ b/activate.sh
@@ -1,7 +1,24 @@
 AUTOENV_AUTH_FILE="${AUTOENV_AUTH_FILE:-$HOME/.autoenv_authorized}"
 AUTOENV_ENV_FILENAME="${AUTOENV_ENV_FILENAME:-.env}"
 AUTOENV_ENV_LEAVE_FILENAME="${AUTOENV_ENV_LEAVE_FILENAME:-.env.leave}"
+AUTOENV_VIEWER=()
 # AUTOENV_ENABLE_LEAVE
+
+# choose a viewer if not already set
+autoenv_setup() {
+  [[ ${#AUTOENV_VIEWER[@]} -gt 0 ]] && return
+  while read -r prog args; do
+    if command -v $prog > /dev/null; then
+      AUTOENV_VIEWER=( "$prog" ${args[@]} )
+      return
+    fi
+  done <<EOF
+  bat --style=numbers
+  less -N
+  cat
+EOF
+}
+autoenv_setup
 
 autoenv_init() {
 
@@ -106,17 +123,12 @@ autoenv_message() {
 }
 
 autoenv_show_file() {
-  local viewer="less" file="$1"
-  local -a viewer=( "less" "-N" )
-
-  if command -v bat > /dev/null; then
-    viewer=( "bat" "--style=numbers" )
-  fi
+  local file="$1"
 
   \echo
   autoenv_message "New or modified env file detected:"
   \printf "\033[1m--- %s contents ----------------------------------------\033[0m\n" "${file##*/}"
-  "${viewer[@]}" "${file}"
+  "${AUTOENV_VIEWER[@]}" "${file}"
   \printf "\033[1m------------------------------------------------------------\033[0m\n\n"
 }
 

--- a/activate.sh
+++ b/activate.sh
@@ -241,5 +241,5 @@ elif command -v shasum 2>/dev/null >&2; then
 	}
 	enable_autoenv
 else
-	\echo "[autoenv] can not locate a compatible shasum binary; not enabling"
+	autoenv_message "can not locate a compatible shasum binary; not enabling"
 fi


### PR DESCRIPTION
This change uses [bat](https://github.com/sharkdp/bat), less, or cat, depending on what is available on the users system to display the contents of new/changed env files. (Configurable via `AUTOENV_VIEWER`.)

Additionally, added an `autoenv_message()` function for colored messages.