### PR TITLE
Cache and revert

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -199,7 +199,7 @@ autoenv_cache() {
   fi
 
   while [[ $# -gt 0 ]]; do
-    if read -r current < <(declare -p $1 2>/dev/null); then
+    if declare -p $1 2>/dev/null | read -r current; then
       AUTOENV_CACHED+=( "${current}" )
     else
       AUTOENV_CACHED+=( "unset $1" )

--- a/activate.sh
+++ b/activate.sh
@@ -1,7 +1,9 @@
+#!/usr/bin/env dash
+
 AUTOENV_AUTH_FILE="${AUTOENV_AUTH_FILE:-$HOME/.autoenv_authorized}"
 AUTOENV_ENV_FILENAME="${AUTOENV_ENV_FILENAME:-.env}"
 AUTOENV_ENV_LEAVE_FILENAME="${AUTOENV_ENV_LEAVE_FILENAME:-.env.leave}"
-AUTOENV_CACHED=()
+unset AUTOENV_CACHED
 # AUTOENV_ENABLE_LEAVE
 
 
@@ -115,7 +117,7 @@ autoenv_check_authz_and_run() {
 		\echo "autoenv:   --- (end contents) -----------------------------------------"
 		\echo "autoenv:"
 		\printf "%s" "autoenv: Are you sure you want to allow this? (y/N) "
-		\read answer
+		\read -r answer
 		if [ "${answer}" = "y" ] || [ "${answer}" = "Y" ]; then
 			autoenv_authorize_env "${_envfile}"
 			autoenv_source "${_envfile}"
@@ -156,8 +158,7 @@ autoenv_source() {
 autoenv_cd() {
 	local _pwd
 	_pwd=${PWD}
-	\command -v chdir >/dev/null 2>&1 && \chdir "${@}" || builtin cd "${@}"
-	if [ "${?}" -eq 0 ]; then
+  if \command -v chdir >/dev/null 2>&1 && \chdir "${@}" || builtin cd "${@}"; then
 		autoenv_init "${_pwd}"
 		\return 0
 	else
@@ -189,21 +190,50 @@ enable_autoenv() {
 	cd "${PWD}"
 }
 
-# cache the previous value of a variable in AUTOENV_CACHED
-autoenv_cache() {
-  local current
+# _autoenv_var_def -- print an expression representing the definition of a variable
+#
+# usage: _autoenv_var_def VAR
+#
+_autoenv_var_def() {
+  local var="$1"
 
-	if [ -z "$AUTOENV_ENABLE_LEAVE" ]; then
-    autoenv_message "Error autoenv_cache is only available with AUTOENV_ENABLE_LEAVE"
+  # use declare -p to get the variable definition when declare is available
+  if type declare 1>/dev/null 2>&1; then
+
+    # if the var is not found, unset to revert
+    if ! declare -p $var 2>/dev/null && echo; then
+      printf "unset %s" "$var"
+    fi
     return
   fi
 
-  while [[ $# -gt 0 ]]; do
-    if declare -p $1 2>/dev/null | read -r current; then
-      AUTOENV_CACHED+=( "${current}" )
-    else
-      AUTOENV_CACHED+=( "unset $1" )
-    fi
+  # get the definition from export
+  if export | command grep "^export ${var}="; then
+    return
+  fi
+
+  # get the definition from set
+  if set | command grep "^${var}="; then
+    return
+  fi
+
+  # if all else has failed, unset to revert
+  printf "unset %s\n" "$var"
+}
+
+# autoenv_cache -- cache the current value of one or more variables in
+#                  AUTOENV_CACHED
+#
+# usage: autoenv_cache VAR...
+#
+autoenv_cache() {
+	if [ -z "$AUTOENV_ENABLE_LEAVE" ]; then
+    echo "Error autoenv_cache is only available with AUTOENV_ENABLE_LEAVE"
+    return
+  fi
+
+  while [ $# -gt 0 ]; do
+    AUTOENV_CACHED="${AUTOENV_CACHED}${AUTOENV_CACHED:+:::}$(_autoenv_var_def $1)"
     shift
   done
 }
@@ -211,10 +241,12 @@ autoenv_cache() {
 # revert all cached variables and clear AUTOENV_CACHE
 autoenv_revert() {
   local expr
-  for expr in "${AUTOENV_CACHED[@]}"; do
+
+  echo "${AUTOENV_CACHED}" | command sed 's/:::/\n/' | while read -r expr ; do
     eval "${expr}"
   done
-  AUTOENV_CACHED=()
+
+  unset AUTOENV_CACHED
 }
 
 if ! $has_alias_func_def_enabled; then

--- a/activate.sh
+++ b/activate.sh
@@ -208,7 +208,7 @@ _autoenv_var_def() {
   fi
 
   # get the definition from export
-  if export | command grep "^export ${var}="; then
+  if export -p | command grep "^export ${var}="; then
     return
   fi
 


### PR DESCRIPTION
This patch provides a `autoenv_cache` function that can be used to cache variables in .env files when leaving is enabled. These are then reverted in `autoenv_leave()`. 