### PR TITLE
Improve internal directory-changing

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -37,10 +37,10 @@ AUTOENV_VIEWER="${AUTOENV_VIEWER:-cat}"
 # @internal
 __autoenv_cd() {
 	if [ "${__autoenv_has_builtin}" = 'yes' ]; then
-		\builtin cd "${1}"
+		\builtin cd "${1}" || return
 	else
 		# Some shells like "dash" do not have "builtin".
-		\chdir "${1}"
+		\chdir "${1}" || return
 	fi
 }
 
@@ -354,6 +354,7 @@ enable_autoenv() {
 		}
 	fi
 
+	# shellcheck disable=SC2164
 	cd "${PWD}"
 }
 

--- a/activate.sh
+++ b/activate.sh
@@ -37,9 +37,9 @@ AUTOENV_VIEWER="${AUTOENV_VIEWER:-cat}"
 # @internal
 __autoenv_cd() {
 	if [ "${__autoenv_has_builtin}" = 'yes' ]; then
-		CDPATH= \builtin cd "${1}"
+		\builtin cd "${1}"
 	else
-		# Shells like "dash" do not have "builtin".
+		# Some shells like "dash" do not have "builtin".
 		\chdir "${1}"
 	fi
 }

--- a/activate.sh
+++ b/activate.sh
@@ -365,7 +365,7 @@ fi
 __autoenv_has_builtin=no
 if __autoenv_output=$(type builtin); then
 	if [ "${__autoenv_output}" = 'builtin is a shell builtin' ]; then
-	__autoenv_has_builtin=yes
+		__autoenv_has_builtin=yes
 	fi
 fi
 unset -v __autoenv_output

--- a/activate.sh
+++ b/activate.sh
@@ -363,7 +363,7 @@ if ! $has_alias_func_def_enabled; then
 fi
 
 __autoenv_has_builtin=no
-if __autoenv_output=$(type builtin); then
+if __autoenv_output=$(\type builtin); then
 	if [ "${__autoenv_output}" = 'builtin is a shell builtin' ]; then
 		__autoenv_has_builtin=yes
 	fi

--- a/activate.sh
+++ b/activate.sh
@@ -34,6 +34,17 @@ AUTOENV_ENV_LEAVE_FILENAME="${AUTOENV_ENV_LEAVE_FILENAME:-.env.leave}"
 AUTOENV_VIEWER="${AUTOENV_VIEWER:-cat}"
 # AUTOENV_ENABLE_LEAVE
 
+# @internal
+__autoenv_cd() {
+	if [ "${__autoenv_has_builtin}" = 'yes' ]; then
+		CDPATH= \builtin cd "${1}"
+	else
+		# Shells like "dash" do not have "builtin".
+		\chdir "${1}"
+	fi
+}
+
+# @internal
 __autoenv_use_color() {
 	if [ ${NO_COLOR+x} ]; then
 		return 1
@@ -98,7 +109,7 @@ autoenv_init() {
 	# Discover all files that we need to source.
 	local _files
 	_files=$(
-		\command -v chdir >/dev/null 2>&1 && \chdir "${_pwd}" || \builtin cd "${_pwd}"
+		__autoenv_cd "${_pwd}"
 		_hadone=''
 		while :; do
 			_file="$(\pwd -P)/${AUTOENV_ENV_FILENAME}"
@@ -113,7 +124,7 @@ ${_file}"
 			fi
 			[ "$(\pwd -P)" = "${_mountpoint}" ] && \break
 			[ "$(\pwd -P)" = "/" ] && \break
-			\command -v chdir >/dev/null 2>&1 && \chdir "$(\pwd -P)/.." || \builtin cd "$(\pwd -P)/.."
+			__autoenv_cd "$(\pwd -P)/.."
 		done
 	)
 
@@ -262,7 +273,7 @@ autoenv_source() {
 # @description Function to override the 'cd' builtin
 autoenv_cd() {
 	local _pwd=${PWD}
-	if \command -v chdir >/dev/null 2>&1 && \chdir "${@}" || \builtin cd "${@}"; then
+	if __autoenv_cd "${@}"; then
 		autoenv_init "${_pwd}"
 		\return 0
 	else
@@ -278,7 +289,7 @@ autoenv_leave() {
 	# Discover all files that we need to source.
 	local _files
 	_files=$(
-		\command -v chdir >/dev/null 2>&1 && \chdir "${from_dir}" || \builtin cd "${from_dir}"
+		__autoenv_cd "${from_dir}"
 		_hadone=''
 		while [ "$PWD" != "" ] && [ "$PWD" != "/" ]; do
 			case $to_dir/ in
@@ -296,7 +307,7 @@ autoenv_leave() {
 ${_file}"
 					fi
 				fi
-				\command -v chdir >/dev/null 2>&1 && \chdir "$(\pwd)/.." || \builtin cd "$PWD/.."
+				__autoenv_cd "$PWD/.."
 				;;
 			esac
 		done
@@ -349,6 +360,14 @@ enable_autoenv() {
 if ! $has_alias_func_def_enabled; then
 	\unsetopt ALIAS_FUNC_DEF 2> /dev/null
 fi
+
+__autoenv_has_builtin=no
+if __autoenv_output=$(type builtin); then
+	if [ "${__autoenv_output}" = 'builtin is a shell builtin' ]; then
+	__autoenv_has_builtin=yes
+	fi
+fi
+unset -v __autoenv_output
 
 # If some shasum exists, specifically use it. Otherwise, do not enable autoenv.
 if \command -v gsha1sum >/dev/null 2>&1; then


### PR DESCRIPTION
Before, changing directories would involve the code `\command -v chdir >/dev/null 2>&1 && \chdir "${_pwd}" || \builtin cd "${_pwd}"`

This had a few issues:

- Console errors from `chdir` was redirected from stderr to stdout
- If a directory could not be `cd`ed to, (not-uncommonly[1]) two errors would be printed. One from `chdir` and one from `cd`
- Runs into shellcheck error: `SC2015 (info): Note that A && B || C is not if-then-else. C may run when A is true`
- `chdir` test runs on every invocation

The new implementation fixes all previous issues.

[1]: Zsh and Dash have `chdir`; `Bash` and `Ksh` do not.